### PR TITLE
Add install instructions for Fedora Linux

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -67,3 +67,10 @@ plugins {
     id 'org.kordamp.gradle.pomchecker' version '{project-version}'
 }
 ----
+
+.Fedora
+[source]
+[subs="attributes"]
+----
+$ sudo dnf install pomchecker-cli
+----


### PR DESCRIPTION
pomchecker-cli is now available in [default repositories](https://packages.fedoraproject.org/pkgs/pomchecker/pomchecker-cli/) for Fedora Linux. Install pomchecker-cli with the following command:
```
sudo dnf install pomchecker-cli
```

sources: https://src.fedoraproject.org/rpms/pomchecker