### PR TITLE
Resolved version conflict with maven-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <picocli.version>4.7.0</picocli.version>
         <sisu.version>0.9.0.M1</sisu.version>
         <maven.version>3.8.7</maven.version>
-        <maven.resolver.version>1.9.4</maven.resolver.version>
+        <maven.resolver.version>1.6.3</maven.resolver.version>
     </properties>
 
     <name>pomchecker</name>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <sisu.version>0.9.0.M1</sisu.version>
         <maven.version>3.8.7</maven.version>
         <maven.resolver.version>1.9.4</maven.resolver.version>
+        <commons.lang3.version>3.12.0</commons.lang3.version>
     </properties>
 
     <name>pomchecker</name>
@@ -74,6 +75,11 @@
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
                 <version>4.4.16</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.12.0</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.sisu</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.12.0</version>
+                <version>${commons.lang3.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.sisu</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <picocli.version>4.7.0</picocli.version>
         <sisu.version>0.9.0.M1</sisu.version>
         <maven.version>3.8.7</maven.version>
-        <maven.resolver.version>1.6.3</maven.resolver.version>
+        <maven.resolver.version>1.9.4</maven.resolver.version>
     </properties>
 
     <name>pomchecker</name>
@@ -150,6 +150,11 @@
             <dependency>
                 <groupId>org.apache.maven.resolver</groupId>
                 <artifactId>maven-resolver-api</artifactId>
+                <version>${maven.resolver.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.resolver</groupId>
+                <artifactId>maven-resolver-impl</artifactId>
                 <version>${maven.resolver.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
maven-core 3.8.6 depends on maven-resolver-* 1.6.3. This should solve the AbstractMethodError (issue #6)